### PR TITLE
fixed concurrency errors

### DIFF
--- a/lib/nosqlite.js
+++ b/lib/nosqlite.js
@@ -33,6 +33,7 @@
       dir: path.resolve(that.path, name),
       name: name || 'test',
       mode: mode || '0775',
+      __cachedIds: {},
       file: function(id) {
         return path.resolve(this.dir, id + '.json');
       },
@@ -85,14 +86,41 @@
         return utile.rimraf.sync(this.dir);
       },
       get: function(id, cb) {
-        return fs.readFile(this.file(id), 'utf8', function(err, data) {
-          return cb(err, (data ? JSON.parse(data) : void 0));
-        });
+        if(this.__cachedIds[id]) {
+          return fs.readFile(this.file(id), 'utf8', function(err, data) {
+            return cb(err, (data ? JSON.parse(data) : void 0));
+          });
+        }
+
+        fs.exists(this.file(id), function (exists) {
+          if(!exists) {
+            fs.writeFile(this.file(id), JSON.stringify({__id: id}), function(err) {
+              if(err) return cb(err);
+
+              this.__cachedIds[id] = true;
+              cb(null, {__id: id});
+            });
+          } else {
+            this.__cachedIds[id] = true;
+            this.get(id, cb);
+          }
+        }.bind(this));
       },
       getSync: function(id) {
-        return JSON.parse(fs.readFileSync(this.file(id), 'utf8'));
+        if(this.__cachedIds[id]) {
+          return JSON.parse(fs.readFileSync(this.file(id), 'utf8'));
+        }
+
+        this.__cachedIds[id] = true;
+        if(!fs.existsSync(this.file(id))) {
+          fs.writeFileSync(this.file(id), JSON.stringify({__id: id}));
+
+          return {__id: id};
+        } else {
+          return this.getSync(id);
+        }
       },
-      "delete": function(id, cb) {
+      delete: function(id, cb) {
         return fs.unlink(this.file(id), cb);
       },
       deleteSync: function(id) {

--- a/lib/nosqlite.js
+++ b/lib/nosqlite.js
@@ -87,16 +87,14 @@
       },
       get: function(id, cb) {
         if(this.__cachedIds[id]) {
-          return fs.readFile(this.file(id), 'utf8', function(err, data) {
+          return fs.readFile("."+ this.file(id), 'utf8', function(err, data) {
             return cb(err, (data ? JSON.parse(data) : void 0));
           });
         }
 
         fs.exists(this.file(id), function (exists) {
           if(!exists) {
-            fs.writeFile(this.file(id), JSON.stringify({_id: id}), function(err) {
-              if(err) return cb(err);
-
+            this._write(id, {_id: id}, function(err) {
               this.__cachedIds[id] = true;
               cb(null, {_id: id});
             });
@@ -113,7 +111,7 @@
 
         this.__cachedIds[id] = true;
         if(!fs.existsSync(this.file(id))) {
-          fs.writeFileSync(this.file(id), JSON.stringify({_id: id}));
+          this._writeSync(id, {_id: id});
 
           return {_id: id};
         } else {

--- a/lib/nosqlite.js
+++ b/lib/nosqlite.js
@@ -94,11 +94,11 @@
 
         fs.exists(this.file(id), function (exists) {
           if(!exists) {
-            fs.writeFile(this.file(id), JSON.stringify({__id: id}), function(err) {
+            fs.writeFile(this.file(id), JSON.stringify({_id: id}), function(err) {
               if(err) return cb(err);
 
               this.__cachedIds[id] = true;
-              cb(null, {__id: id});
+              cb(null, {_id: id});
             });
           } else {
             this.__cachedIds[id] = true;
@@ -113,9 +113,9 @@
 
         this.__cachedIds[id] = true;
         if(!fs.existsSync(this.file(id))) {
-          fs.writeFileSync(this.file(id), JSON.stringify({__id: id}));
+          fs.writeFileSync(this.file(id), JSON.stringify({_id: id}));
 
-          return {__id: id};
+          return {_id: id};
         } else {
           return this.getSync(id);
         }

--- a/lib/nosqlite.js
+++ b/lib/nosqlite.js
@@ -53,19 +53,17 @@
         });
       },
       _write: function(id, data, cb) {
-        return fs.writeFile(this.file('.' + id), data, (function(_this) {
+        return fs.writeFile(this.file(id), data, (function(_this) {
           return function(err) {
-            if (err) {
-              return cb(err);
-            } else {
-              return fs.rename(_this.file('.' + id), _this.file(id), cb);
-            }
+            // throw the error as deep as possible to be able to get a nice
+            // stack trace
+            cb(err, data);
           };
         })(this));
       },
       _writeSync: function(id, data) {
-        fs.writeFileSync(this.file('.' + id), data);
-        return fs.renameSync(this.file('.' + id), this.file(id));
+        fs.writeFileSync(this.file(id), data);
+        return data;
       },
       exists: function(cb) {
         return fs.exists(this.dir, cb);
@@ -92,17 +90,20 @@
           });
         }
 
-        fs.exists(this.file(id), function (exists) {
-          if(!exists) {
-            this._write(id, {_id: id}, function(err) {
-              this.__cachedIds[id] = true;
-              cb(null, {_id: id});
-            });
-          } else {
-            this.__cachedIds[id] = true;
-            this.get(id, cb);
-          }
-        }.bind(this));
+        fs.exists(this.file(id), (function(_this) {
+          return function (exists) {
+            if(!exists) {
+              _this._write(id, {_id: id}, function(err) {
+                if(!err) cb(null, {_id: id});
+
+                cb(err);
+              });
+            } else {
+              _this.__cachedIds[id] = true;
+              _this.get(id, cb);
+            }
+          };
+        })(this));
       },
       getSync: function(id) {
         if(this.__cachedIds[id]) {
@@ -125,10 +126,10 @@
         return fs.unlinkSync(this.file(id));
       },
       put: function(id, obj, cb) {
-        return this.get(id, (function(_this) {
+        return this.get(id, (function(_this){
           return function(err, data) {
             data = _this.project(data, obj);
-            return _this._write(id, JSON.stringify(data, null, 2), cb);
+            _this._write(id, JSON.stringify(data, null, 2), cb);
           };
         })(this));
       },
@@ -143,22 +144,17 @@
             obj[key] = cuid();
           }
           return this._write(obj[key], JSON.stringify(obj, null, 2), function(err) {
-            if (err) {
-              return cb(err);
-            } else {
-              return cb(null, obj[key]);
-            }
+            if(!err) return cb(null, obj[key]);
+
+            return cb(err);
           });
         } else {
           if (!(obj.id || obj._id)) {
             obj.id = cuid();
           }
           return this._write(obj.id || obj._id, JSON.stringify(obj, null, 2), function(err) {
-            if (err) {
-              return cb(err);
-            } else {
-              return cb(null, obj.id || obj._id);
-            }
+            if(!err) return cb(null, obj.id || obj._id);
+            return cb(err);
           });
         }
       },
@@ -211,7 +207,7 @@
           };
         })(this));
         return files.filter(function(file) {
-          return file != null;
+          return file !== null;
         });
       },
       all: function(cb) {


### PR DESCRIPTION
This PR aims at fixing some concurrency errors. Here's the setting.
- there are two concurrent calls to this._write, both are at the stage of calling the callback of writeFile (going to do the renaming).
- one function renames the file called this.file("." + id) to this.file(id), then the other callback executes, and tries to do the same renaming. 
- fs.rename won't find the file called this.file("." + id) because it was just renamed, so it'll throw an error. 
Removing this renaming stage fixes the problem.